### PR TITLE
Modify path handling in web.rs, fix  when ".tar" is file download

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -35,7 +35,7 @@ async fn handle_tar(
     tail: web::Path<String>,
 ) -> impl Responder {
     let relpath = PathBuf::from(tail.trim_end_matches('/'));
-    let fullpath = root.join(&relpath).canonicalize().unwrap();
+    let fullpath = root.join(&relpath);
 
     // if a .tar already exists, just return it as-is
     let mut fullpath_tar = fullpath.clone();


### PR DESCRIPTION
when i down load .tar  file not tar path, 
occur this error _" thread 'actix-rt|system:0|arbiter:0' (8195) panicked at src/web.rs:38:55:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }"_
Remove canonicalization of the file path, fix it.